### PR TITLE
Compatibility with (outdated) TeX Live 2017 on Ubuntu 18.04

### DIFF
--- a/beamerfontthemejku.sty
+++ b/beamerfontthemejku.sty
@@ -83,6 +83,10 @@
 \RequirePackage{helvet}
 \RequirePackage{euler}
 \RequirePackage{fontawesome5}
+\ifxetex\else%
+    % fix potentially mis-packaged FA5 in TeX Live 2017, see https://tex.stackexchange.com/q/497792/290236
+    \pdfmapfile{=fontawesome5.map}%
+\fi
 %\usefonttheme{serif}
 \usefonttheme{professionalfonts}
 

--- a/beamerthemejku.sty
+++ b/beamerthemejku.sty
@@ -382,18 +382,11 @@
     \fi%
     \let\input@path\Ginput@path%
     \@ifundefined{set@curr@file}{%
-        \def\set@curr@file#1{%
-            \begingroup
-                \escapechar\m@ne
-                \xdef\@curr@file{\expandafter\string\csname #1\endcsname}%
-            \endgroup
-        }%
-    }{}%
-    \@ifundefined{quote@name}{\def\quote@name#1{"\quote@@name#1\@gobble""}}{}%
-    \@ifundefined{quote@name}{\def\quote@@name#1"{#1\quote@@name}}{}%
-    \@ifundefined{quote@name}{\def\unquote@name#1{\quote@@name#1\@gobble"}}{}%
-    \set@curr@file{#1}%
-    \expandafter\filename@parse\expandafter{\@curr@file}%
+        \filename@parse{#1}%
+    }{%
+        \set@curr@file{#1}%
+        \expandafter\filename@parse\expandafter{\@curr@file}%
+    }%
     \ifx\filename@ext\Gin@gzext%
         \expandafter\filename@parse\expandafter{\filename@base}%
         \ifx\filename@ext\relax%

--- a/beamerthemejku.sty
+++ b/beamerthemejku.sty
@@ -381,6 +381,17 @@
         \edef\Gin@extensions{\detokenize\expandafter{\Gin@extensions}}%
     \fi%
     \let\input@path\Ginput@path%
+    \@ifundefined{set@curr@file}{%
+        \def\set@curr@file#1{%
+            \begingroup
+                \escapechar\m@ne
+                \xdef\@curr@file{\expandafter\string\csname #1\endcsname}%
+            \endgroup
+        }%
+    }{}%
+    \@ifundefined{quote@name}{\def\quote@name#1{"\quote@@name#1\@gobble""}}{}%
+    \@ifundefined{quote@name}{\def\quote@@name#1"{#1\quote@@name}}{}%
+    \@ifundefined{quote@name}{\def\unquote@name#1{\quote@@name#1\@gobble"}}{}%
     \set@curr@file{#1}%
     \expandafter\filename@parse\expandafter{\@curr@file}%
     \ifx\filename@ext\Gin@gzext%


### PR DESCRIPTION
This PR introduces a few fixes to make the template compatible with TeX Live 2017 on Ubuntu 18.04 (if, for whatever reason, users choose to still work with an EoL system).