### PR TITLE
Fix paths to allow package to be installed (to $TEXMF[LOCAL|HOME])

### DIFF
--- a/beamerfontthemejku.sty
+++ b/beamerfontthemejku.sty
@@ -40,7 +40,7 @@
 %% 
 
 % Option fontpath={}: set path to template font resources (defaults to "./fonts")
-\newcommand{\jkubeamer@fontpath}{./fonts}
+\newcommand{\jkubeamer@fontpath}{fonts}
 \DeclareOptionBeamer{fontpath}{\renewcommand{\jkubeamer@fontpath}{#1}}
 
 % Option [no]fancyfonts: use custom TTF fonts with XeTeX (defaults to true)
@@ -101,7 +101,7 @@
     \expandafter\IfFileExists\expandafter{\jkubeamer@fontpath PublicSans-Regular.ttf}{%
     }{\expandafter\IfFileExists\expandafter{\jkubeamer@fontpath/PublicSans-Regular.ttf}{%
         \xdef\jkubeamer@fontpath{\jkubeamer@fontpath/}
-    }{%
+        }{%
         \PackageError{beamerfontthemejku}{Font files not found in `\jkubeamer@fontpath', forgot to set the font path with package option `fontpath='?}{}%
         \stop
     }}

--- a/beamerfontthemejku.sty
+++ b/beamerfontthemejku.sty
@@ -98,15 +98,30 @@
 \fi
 
 \ifbool{jkubeamer@xetexfonts}{%
+    \RequirePackage[no-math]{fontspec}
+    % discover font path
     \expandafter\IfFileExists\expandafter{\jkubeamer@fontpath PublicSans-Regular.ttf}{%
+        \IfFontExistsTF{\jkubeamer@fontpath PublicSans-Regular.ttf}{%
+        }{%
+            \xdef\jkubeamer@fontpath{}
+        }%
     }{\expandafter\IfFileExists\expandafter{\jkubeamer@fontpath/PublicSans-Regular.ttf}{%
         \xdef\jkubeamer@fontpath{\jkubeamer@fontpath/}
+        \IfFontExistsTF{\jkubeamer@fontpath PublicSans-Regular.ttf}{%
         }{%
+            \xdef\jkubeamer@fontpath{}
+        }%
+    }{\IfFontExistsTF{PublicSans-Regular.ttf}{%
+        \xdef\jkubeamer@fontpath{}
+    }{%
         \PackageError{beamerfontthemejku}{Font files not found in `\jkubeamer@fontpath', forgot to set the font path with package option `fontpath='?}{}%
         \stop
-    }}
-    
-    \RequirePackage[no-math]{fontspec}
+    }}}%
+    \IfFontExistsTF{\jkubeamer@fontpath PublicSans-Regular.ttf}{%
+    }{%
+        \PackageError{beamerfontthemejku}{Font files not found in local installation. Fonts must be installed to `$TEXMF[HOME|LOCAL]/fonts/truetype/' or an alternative font path set with package option `fontpath='}{}%
+        \stop
+    }%
     \defaultfontfeatures{
         Path={\jkubeamer@fontpath},
         Extension=.ttf,

--- a/beamerthemejku.sty
+++ b/beamerthemejku.sty
@@ -44,7 +44,7 @@
 %% 
 
 % Option logopath={}: set path to template logo resources (defaults to "./logos")
-\newcommand{\jkubeamer@logopath}{./logos}
+\newcommand{\jkubeamer@logopath}{logos}
 \DeclareOptionBeamer{logopath}{\renewcommand{\jkubeamer@logopath}{#1}}
 
 % Option [no]frametitlecaps: set frame titles in all-caps (defaults to false)


### PR DESCRIPTION
See #3 

For images, the fix is to simply remove the leading "./" from the relative path. This permits LaTeX to search the whole \input@path (?!) instead of being just relative to the TeX document root.

For fonts, its a bit more complicated, since installed fonts are not located in the package installation directory but in a dedicated fonts directory ($TEXMF[LOCAL|HOME]/fonts/truetype/). When installing, the package, fonts need to be moved there (either directly or in subdirectories). This fix attempts to detect if fonts are installed into the appropriate location and tries to warn the user if fonts are found in the package directory.
