### PR TITLE
Fix block body font for alertblock and exampleblock

### DIFF
--- a/beamerthemejku.sty
+++ b/beamerthemejku.sty
@@ -2271,7 +2271,7 @@
     \end{beamercolorbox}%
     \nointerlineskip
     \begin{beamercolorbox}[sep=1ex,vmode]{block body example}%
-        \usebeamerfont{block body}%
+        \usebeamerfont{block body example}%
         \setlength{\leftmargini}{\dimexpr\leftmargini + 1ex + 0.125em\relax}%
         \begin{minipage}{\dimexpr\textwidth-2ex\relax}%
 }
@@ -2298,7 +2298,7 @@
     \end{beamercolorbox}%
     \nointerlineskip
     \begin{beamercolorbox}[sep=1ex,vmode]{block body alerted}%
-        \usebeamerfont{block body}%
+        \usebeamerfont{block body alerted}%
         \setlength{\leftmargini}{\dimexpr\leftmargini + 1ex + 0.125em\relax}%
         \begin{minipage}{\dimexpr\textwidth-2ex\relax}%
 }


### PR DESCRIPTION
alertblock and exampleblock environments incorrectly use the regular block body font instead of the "alerted" and "example" versions. This PR attempts to fix this issue by using the correct fonts in the body box.